### PR TITLE
csv school script

### DIFF
--- a/scripts/csv-schools.js
+++ b/scripts/csv-schools.js
@@ -11,6 +11,19 @@ const unproj = proj4(
 
 const url = 'https://www.data.gouv.fr/s/resources/adresse-et-geolocalisation-des-etablissements-denseignement-du-premier-et-second-degres/20160526-143453/DEPP-etab-1D2D.csv'
 
+
+const rawName = /^(?:.cole (?:primaire|maternelle|.l.mentaire) *(?:d.application|a|b|priv.e|publique|[1-9])*|coll.ge)$/i
+
+function name(row) {
+  let name = row.appellation_officielle
+  if (!name) {
+    name = `${row.denomination_principale} ${row.patronyme_uai}`
+  } else if (name.match(rawName)) {
+    name = `${name} ${row.patronyme_uai}`
+  }
+  return name
+}
+
 async function parse () {
   const rows = await getStream(
     request(url)
@@ -27,7 +40,7 @@ async function parse () {
       const x = parseFloat(r.coordonnee_x.replace(/,/g, '.'))
       const y = parseFloat(r.coordonnee_y.replace(/,/g, '.'))
       return {
-        name: row.appellation_officielle,
+        name: name(row),
         postalCode: row.code_postal_uai,
         city: row.localite_acheminement_uai,
         loc: {

--- a/scripts/csv-schools.js
+++ b/scripts/csv-schools.js
@@ -11,10 +11,9 @@ const unproj = proj4(
 
 const url = 'https://www.data.gouv.fr/s/resources/adresse-et-geolocalisation-des-etablissements-denseignement-du-premier-et-second-degres/20160526-143453/DEPP-etab-1D2D.csv'
 
-
 const rawName = /^(?:.cole (?:primaire|maternelle|.l.mentaire) *(?:d.application|a|b|priv.e|publique|[1-9])*|coll.ge)$/i
 
-function name(row) {
+function name (row) {
   let name = row.appellation_officielle
   if (!name) {
     name = `${row.denomination_principale} ${row.patronyme_uai}`

--- a/scripts/csv-schools.js
+++ b/scripts/csv-schools.js
@@ -14,13 +14,13 @@ const url = 'https://www.data.gouv.fr/s/resources/adresse-et-geolocalisation-des
 const rawName = /^(?:.cole (?:primaire|maternelle|.l.mentaire) *(?:d.application|a|b|priv.e|publique|[1-9])*|coll.ge)$/i
 
 function name (row) {
-  let name = row.appellation_officielle
-  if (!name) {
-    name = `${row.denomination_principale} ${row.patronyme_uai}`
-  } else if (name.match(rawName)) {
-    name = `${name} ${row.patronyme_uai}`
+  const official = row.appellation_officielle
+  if (!official) {
+    return `${row.denomination_principale} ${row.patronyme_uai}`
+  } else if (official.match(rawName)) {
+    return `${official} ${row.patronyme_uai}`
   }
-  return name
+  return official
 }
 
 async function parse () {


### PR DESCRIPTION
J'ai fait évoluer le script d'import des écoles pour avoir des noms mieux qualifiés. 

Certaines écoles avaient seulement "École primaire"  comme nom d'école, mais ont parfois un "patronime", souvent lié au lieu (nom de la rue). Le script permet de rajouter ce patronyme à la fin des écoles qui n'ont pas de dénomination précise,  par exemple : « École primaire » est remplacé par « École primaire CHARENTON ». Il permet aussi de mettre un nom sur les écoles qui n'avaient pas du tout de npm en allant chercher dans les autres colonnes.

Quelques tests manuels m'ont montré que c'est "mieux".