### PR TITLE
accept empty search

### DIFF
--- a/routes/actors.js
+++ b/routes/actors.js
@@ -27,14 +27,15 @@ router
     apiRender(ctx, actor)
   })
 
-  .get('/search/:q', async ctx => {
+  .get('/search/:q*', async ctx => {
     // Perform a _logical AND_ search
-    const words = ctx.params.q.replace(/\s+/, ' ').split(' ').map(w => `"${w}"`).join(' ')
-    const criteria = {
+    const words = ctx.params.q
+    const criteria = !words ? {} : {
       $text: {
-        $search: words
+        $search: words.replace(/\s+/, ' ').split(' ').map(w => `"${w}"`).join(' ')
       }
     }
+    
     // Filter with certain domains
     const domains = ctx.request.query.domains && ctx.request.query.domains.split(',')
     if (domains) {


### PR DESCRIPTION
On peut maintenant passer à l'API un champ de recherche vide pour les acteurs. L'indentation des opérateurs ternaire est toujours un problème pour moi (lié au `const`), je ne sais pas quel choix faire : ça m'énerve de faire ça, j'ai l'impression de faire un _hack_ pour affecter.

Pour ça j'aime bien l'approche du Rust qui résout ce problème par la [syntaxe suivante](http://play.integer32.com/?gist=d8bc6bebaf73d3616a2a09e2c84de4d1&version=stable&mode=debug&edition=2015) (dans cet exemple, `let` en Rust est similaire au `const` du JS) : 

```rust
let my_var = if a == 1 {
    56
} else {
    32
};
```