### PR TITLE
split actors and actions

### DIFF
--- a/migrations/index.js
+++ b/migrations/index.js
@@ -1,0 +1,20 @@
+/* globals db */
+
+// Get all actors having actions, then create a document for each and unset actions in actors.
+db.actors.find({
+  'actions.0': {
+    $exists: true
+  }
+}).forEach(actor => {
+  actor.actions.forEach(action => {
+    action.actorId = actor._id
+    db.actions.insert(action)
+    db.actors.update({
+      _id: actor._id
+    }, {
+      $unset: {
+        actions: ''
+      }
+    })
+  })
+})

--- a/models/action.js
+++ b/models/action.js
@@ -3,7 +3,8 @@ const mongoose = require('mongoose')
 const ActionSchema = new mongoose.Schema({
   name: { type: String, required: true },
   description: { type: String },
-  actorId: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Actor' }]
+  actorId: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Actor' }],
+  createdAt: { type: Date, default: Date.now }
 }, {
   strict: false
 })

--- a/models/action.js
+++ b/models/action.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose')
+
+const ActionSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  description: { type: String },
+  actorId: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Actor' }]
+}, {
+  strict: false
+})
+
+class Action {}
+
+ActionSchema.index({
+  name: 'text',
+  description: 'text'
+}, {
+  default_language: 'french'
+})
+ActionSchema.loadClass(Action)
+
+ActionSchema.set('toObject', {
+  getters: true
+})
+ActionSchema.set('toJSON', {
+  getters: true
+})
+
+module.exports = mongoose.model('Action', ActionSchema)

--- a/models/actor.js
+++ b/models/actor.js
@@ -11,7 +11,8 @@ const ActorSchema = new mongoose.Schema({
   loc: { type: Object, index: '2dsphere' },
   domains: Array,
   contactName: String,
-  distance: Number
+  distance: Number,
+  actions: Array
 }, {strict: false})
 
 class Actor {
@@ -23,7 +24,7 @@ class Actor {
 }
 
 ActorSchema.index({ name: 'text', description: 'text' },
-                  { default_language: 'french' })
+  { default_language: 'french' })
 ActorSchema.loadClass(Actor)
 
 ActorSchema.set('toObject', { getters: true })

--- a/models/actor.js
+++ b/models/actor.js
@@ -23,8 +23,10 @@ class Actor {
   }
 }
 
-ActorSchema.index({ name: 'text', description: 'text' },
-  { default_language: 'french' })
+ActorSchema.index(
+  { name: 'text', description: 'text' },
+  { default_language: 'french' }
+)
 ActorSchema.loadClass(Actor)
 
 ActorSchema.set('toObject', { getters: true })

--- a/models/actor.js
+++ b/models/actor.js
@@ -12,7 +12,8 @@ const ActorSchema = new mongoose.Schema({
   domains: Array,
   contactName: String,
   distance: Number,
-  actions: Array
+  actions: Array,
+  createdAt: { type: Date, default: Date.now }
 }, {strict: false})
 
 class Actor {

--- a/routes/actors.js
+++ b/routes/actors.js
@@ -8,6 +8,7 @@ const utils = require('../utils')
 const apiRender = utils.apiRender
 
 const Actor = require('../models/actor')
+const Action = require('../models/action')
 
 router
   .get('/', async ctx => {
@@ -71,7 +72,7 @@ router
       actors = await Actor.find(criteria).limit(limit)
     }
 
-    switch(format) {
+    switch (format) {
       case 'csv':
         const stream = csvWriter()
         actors.forEach(model => {
@@ -95,6 +96,7 @@ router
     const actor = await Actor.findOne({
       _id: ctx.params.id
     })
+    actor.actions = await Action.find({actorId: actor._id})
     actor.location = ctx.request.query.from
     apiRender(ctx, actor)
   })


### PR DESCRIPTION
J'ai mis en place la séparation entre _acteurs_ et _actions_. L'objectif ici était de rester compatible avec le front tel qu'il est. Donc ça "imite" l'ancien système (see: https://github.com/betagouv/eac-api/compare/split-actions?expand=1#diff-c55ac538ea96ac72a09f05a24cd98c88R99). 

Dans le détail, je me suis référé à la documentation de mongoose pour les clés étrangères qui dit de faire d'un côté la référence (dans `Action`) et de l'autre "à la main" pour ne pas dupliquer les clés. Encore une fois j'ai galéré mais j'apprends.

Attention ! Il faut lancer les migrations (`mongo eac migrations`) en même temps que la mise à jour à lieu. Si tu acceptes, tu peux t'en charger après relecture (tu valide, tu lance la migration puis tu merge ou je merge comme tu veux, mais il faut être synchro). Sinon, je peux aussi la lancer moi-même mais il me faudra ta confirmation (dans ce ticket) que tu as pu tester sur ton poste et que ça fonctionne.

Les étapes suivantes seront de faire évoluer le front et l'API (par exemple pour pouvoir appeler une action directement sans passer par son acteur/0)