### PR TITLE
fix createdAt and deletedAt

### DIFF
--- a/migrations/index.js
+++ b/migrations/index.js
@@ -1,6 +1,6 @@
 /* globals db */
 
-// Get all actors having actions, then create a document for each and unset actions in actors.
+print("Get all actors having actions, then create a document for each and unset actions in actors.")
 db.actors.find({
   'actions.0': {
     $exists: true
@@ -18,3 +18,43 @@ db.actors.find({
     })
   })
 })
+
+print("Set updatedAt and createdAt...") 
+const origin = new Date('2018-07-01')
+
+print("  ... No date at all") 
+db.actors.find({
+  updatedAt: null,
+  createdAt: null
+}).forEach(actor => {
+  db.actors.update({
+    _id: actor._id
+  }, {
+    updatedAt: origin,
+    createdAt: origin
+  })
+})
+
+print("  ... Only updatedAt, no createdAt")
+db.actors.find({
+  createdAt: null
+}).forEach(actor => {
+  db.actors.update({
+    _id: actor._id
+  }, {
+    createdAt: actor.updatedAt
+  })
+})
+
+print("  ... Only createdAt, no updatedAt")
+db.actors.find({
+  updatedAt: null
+}).forEach(actor => {
+  db.actors.update({
+    _id: actor._id
+  }, {
+    updatedAt: actor.createdAt
+  })
+})
+
+print("Done 🎊")

--- a/migrations/index.js
+++ b/migrations/index.js
@@ -19,10 +19,10 @@ db.actors.find({
   })
 })
 
-print("Set updatedAt and createdAt...") 
+print("Set updatedAt and createdAt...")
 const origin = new Date('2018-07-01')
 
-print("  ... No date at all") 
+print("  ... No date at all")
 db.actors.find({
   updatedAt: null,
   createdAt: null
@@ -30,8 +30,10 @@ db.actors.find({
   db.actors.update({
     _id: actor._id
   }, {
-    updatedAt: origin,
-    createdAt: origin
+    $set: {
+      updatedAt: origin,
+      createdAt: origin
+    }
   })
 })
 
@@ -42,7 +44,9 @@ db.actors.find({
   db.actors.update({
     _id: actor._id
   }, {
-    createdAt: actor.updatedAt
+    $set: {
+      createdAt: actor.updatedAt
+    }
   })
 })
 
@@ -53,7 +57,9 @@ db.actors.find({
   db.actors.update({
     _id: actor._id
   }, {
-    updatedAt: actor.createdAt
+    $set: {
+      updatedAt: actor.createdAt
+    }
   })
 })
 


### PR DESCRIPTION
See: https://github.com/betagouv/eac/pull/52/#discussion_r212453723

@vinyll L'objectif est de nettoyer la base de données, pour qu'il y ait des `updatedAt` et `createdAt` partout, _à la_ Laravel, plutôt que de faire de post-fix côté front. Les scripts d'imports n'ont pas été changés car ils sont quasi obsolète et ils se basent justement sur les updatedAt et createdAt. Côté création et mise à jour dans la plateforme c'est bon, les données sont bien renseignées.