### PR TITLE
Migration date range

### DIFF
--- a/migrations/index.js
+++ b/migrations/index.js
@@ -124,14 +124,21 @@ addDomain(['philosophie'], 'Philosophie')
 addDomain(['écolo', 'ecolo'], 'Développement durable')
 
 print('Update timetable for all actions with obsolete dateRange...')
+
+const toFrDate = date => {
+  date = new Date(date)
+  return `${('0' + date.getDate()).slice(-2)}/${('0' + (date.getMonth()+1)).slice(-2)}/${date.getFullYear()}`
+}
+
 db.actions.find({ dateRange: { $ne:null } }).forEach(action => {
+  const dr = action.dateRange
   let text = [ action.timetable ]
-  if (action.dateRange[0] && action.dateRange[1]) {
-    text.push(`Disponible entre le ${action.dateRange[0]} et le ${action.dateRange[1]}`)
-  } else if (action.dateRange[0] && !action.dateRange[1]) {
-    text.push(`Débute le ${action.dateRange[0]}`)
-  } else if (!action.dateRange[0] && action.dateRange[1]) {
-    text.push(`Effective jusqu'au ${action.dateRange[1]}`)
+  if (dr[0] && dr[1]) {
+    text.push(`Disponible entre le ${toFrDate(dr[0])} et le ${toFrDate(dr[1])}`)
+  } else if (dr[0] && !dr[1]) {
+    text.push(`Débute le ${toFrDate(dr[0])}`)
+  } else if (!dr[0] && dr[1]) {
+    text.push(`Effective jusqu'au ${toFrDate(dr[1])}`)
   }
   text = text.filter(t => t).join('\n')
   db.actions.update({ _id: action._id }, { $set: { timetable: text }, $unset: { dateRange: '' } })

--- a/migrations/index.js
+++ b/migrations/index.js
@@ -123,4 +123,19 @@ addDomain(['danse'], 'Danse')
 addDomain(['philosophie'], 'Philosophie')
 addDomain(['écolo', 'ecolo'], 'Développement durable')
 
+print('Update timetable for all actions with obsolete dateRange...')
+db.actions.find({ dateRange: { $ne:null } }).forEach(action => {
+  let text = [ action.timetable ]
+  if (action.dateRange[0] && action.dateRange[1]) {
+    text.push(`Disponible entre le ${action.dateRange[0]} et le ${action.dateRange[1]}`)
+  } else if (action.dateRange[0] && !action.dateRange[1]) {
+    text.push(`Débute le ${action.dateRange[0]}`)
+  } else if (!action.dateRange[0] && action.dateRange[1]) {
+    text.push(`Effective jusqu'au ${action.dateRange[1]}`)
+  }
+  text = text.filter(t => t).join('\n')
+  db.actions.update({ _id: action._id }, { $set: { timetable: text }, $unset: { dateRange: '' } })
+  print(` ...update timetable for action ${action._id} with value:\n${text}`)
+})
+
 print('Done 🎊')


### PR DESCRIPTION
Actuellement, il existe deux propriétés `dateRange` et `timetable`. On va donc se débarasser de  `dateRange`, en transformant son contenu pour en faire un texte à ajouter à la fin de `timeTable`.

Avant :
```javascript
{timetable: 'de 15h à 16h', dateRange: ['2018-09-27', '2018-09-28']}
```

Après :
```javascript
{timetable: 'de 15h à 16h\nDisponible entre le 21/09/2018 et le 22/09/2018'}
```

(c'est basé sur les textes de la partie front).

@vinyll Je te laisse review avant de merge et de lancer le script. L'étape suivante sera de livrer l'affichage de cette timetable sur le front (qui n'est actuellement pas utilisée) et de supprimer du formulaire les dateRange.