### PR TITLE
passport+jwt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1404,6 +1404,11 @@
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -2087,6 +2092,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -4306,6 +4319,29 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+      "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
+      "requires": {
+        "jws": "^3.1.5",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4316,6 +4352,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "requires": {
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kareem": {
@@ -4413,6 +4468,41 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -5101,6 +5191,29 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
+    "passport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-jwt": {
+      "version": "4.0.0",
+      "resolved": "http://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
+      "requires": {
+        "jsonwebtoken": "^8.2.0",
+        "passport-strategy": "^1.0.0"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -5143,6 +5256,11 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pause-stream": {
       "version": "0.0.11",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,11 @@
     "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "express": "^4.16.3",
+    "jsonwebtoken": "^8.3.0",
     "mongoose": "^5.3.0",
-    "nodemon": "^1.18.4"
+    "nodemon": "^1.18.4",
+    "passport": "^0.4.0",
+    "passport-jwt": "^4.0.0"
   },
   "devDependencies": {
     "csv-parse": "^2.5.0",

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,8 @@
 const express = require('express')
 const cors = require('cors')
 const bodyParser = require('body-parser')
+const passport = require("passport")
+require("./passport")(passport)
 const app = express()
 
 const mongoose = require('mongoose')
@@ -9,6 +11,7 @@ mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost/eac', { useNewU
 app.use(cors())
 app.use(bodyParser.urlencoded({extended: true}))
 app.use(bodyParser.json())
+app.use(passport.initialize())
 
 app.use('/actions', require('./routes/actions'))
 app.use('/actors', require('./routes/actors'))

--- a/src/app.js
+++ b/src/app.js
@@ -1,8 +1,8 @@
 const express = require('express')
 const cors = require('cors')
 const bodyParser = require('body-parser')
-const passport = require("passport")
-require("./passport")(passport)
+const passport = require('passport')
+require('./passport')(passport)
 const app = express()
 
 const mongoose = require('mongoose')

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  secret: process.env.SECRET || 'not so secret…'
+}

--- a/src/passport.js
+++ b/src/passport.js
@@ -1,0 +1,18 @@
+const { Strategy, ExtractJwt } = require('passport-jwt')
+const configSecret = require('./config').secret
+const User = require('./models/user')
+
+module.exports = function(passport) {
+  const opts = {
+    jwtFromRequest: ExtractJwt.fromAuthHeaderWithScheme('JWT'),
+    secretOrKey: configSecret
+  }
+  passport.use(new Strategy(opts, async function(jwtPayload, done) {
+    try {
+      const user = await User.findOne({ _id: jwtPayload._id })
+      return done(null, user || false)
+    } catch (e) {
+      return done(e, false)
+    }
+  }))
+}

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -28,7 +28,6 @@ router
 
   .post('/signin', async (req, res) => {
     const params = req.body
-    console.log(params)
     if (!params.email || !params.password) {
       return res.status(400).send({ message: 'Email and password required.' })
     }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,8 +1,11 @@
 const router = require('express').Router()
 const User = require('../models/user')
+const configSecret = require('../config').secret
+const jwt = require('jsonwebtoken')
+const passport = require('passport')
 
 router
-  .post('/signup', async (res, req) => {
+  .post('/signup', async (req, res) => {
     const params = req.body
     if (!params.email || !params.password || !params.name) {
       return res.status(400).send({ message: 'Email, password and name required.' })
@@ -23,15 +26,26 @@ router
     }
   })
 
-  .post('/signin', async (res, req) => {
+  .post('/signin', async (req, res) => {
     const params = req.body
+    console.log(params)
+    if (!params.email || !params.password) {
+      return res.status(400).send({ message: 'Email and password required.' })
+    }
     const message = 'Invalid email or password.'
     const user = await User.findOne({ email: params.email })
     if (!user) {
       return res.status(401).send({ message })
     }
-    const match = await user.comparePassword(params.password)
-    return match ? res.send({ token: 'JWT - TODO', user }) : res.status(401).send({ message })
+    if (await user.comparePassword(params.password)) {
+      const token = jwt.sign({ _id: user._id }, configSecret, { expiresIn: '7d' })
+      return res.send({ token: `JWT ${token}`, user })
+    }
+    return res.status(401).send({ message })
+  })
+
+  .get('/user', passport.authenticate('jwt', { session: false }), (req, res) => {
+    res.send({ user: req.user })
   })
 
 module.exports = router


### PR DESCRIPTION
@vinyll Le principe est de renvoyer dans la route `signin` un token valide 7 jours. Ensuite, il est possible de protéger des routes (et de retrouver l'utilisateur en question) de la manière suivante : 

```javascript
router.get('/foo', passport.authenticate('jwt', { session: false }), (req, res) => {
  res.send(`On sait qui tu es: ${req.user.email}`)
})
```

Je propose qu'on aille pas plus loin dans l'authentification pour le moment. Le système est en place on l'activera quand tu veux. À ta dispo pour travailler ensuite sur le front et la partie feedback.

PS: il faudra ensuite ajouter une variable d'env `SECRET` chez clevercloud.