### PR TITLE
🏇 remove set location add setDistance

### DIFF
--- a/src/models/action.js
+++ b/src/models/action.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose')
-const utils = require('../utils')
 
 const ActionSchema = new mongoose.Schema({
   name: { type: String, required: true },
@@ -12,13 +11,7 @@ const ActionSchema = new mongoose.Schema({
   strict: false
 })
 
-class Action {
-  set location (latLng) {
-    if (!this.loc.coordinates[0]) return
-    if (typeof (latLng) === 'string') latLng = latLng.split(',').map(v => Number(v))
-    this.distance = utils.distance(latLng, this.loc.coordinates)
-  }
-}
+class Action {}
 
 ActionSchema.index({
   name: 'text',

--- a/src/models/actor.js
+++ b/src/models/actor.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose')
-const utils = require('../utils')
 const { cleanPostalCode, departmentOnSave } = require('../signals')
 const { PostalCode, Department } = require('../schematypes')
 
@@ -28,11 +27,6 @@ cleanPostalCode(ActorSchema)
 departmentOnSave(ActorSchema)
 
 class Actor {
-  set location (latLng) {
-    if (!this.loc.coordinates[0]) return
-    if (typeof (latLng) === 'string') latLng = latLng.split(',').map(v => Number(v))
-    this.distance = utils.distance(latLng, this.loc.coordinates)
-  }
   toCsv () {
     const actor = this._doc
     actor.location = actor.loc && actor.loc.coordinates.join(',')

--- a/src/routes/actions.js
+++ b/src/routes/actions.js
@@ -1,5 +1,5 @@
 const router = require('express').Router()
-const {apiRenderCsv, searchCriteria, setDistance} = require('../utils')
+const {apiRenderCsv, searchCriteria, distance} = require('../utils')
 
 const Action = require('../models/action')
 
@@ -42,7 +42,7 @@ router
     if (from) {
       actions = await Action.aggregate(criteria)
       actions.forEach(action => {
-        setDistance(action, location)
+        action.distance = distance(action.loc.coordinates, location)
       })
       actions.sort((a, b) => a.distance - b.distance)
       actions = actions.splice(0, limit)
@@ -65,7 +65,7 @@ router
     action._doc.actor = action.actorId // actorId should be called "actor"!
     delete action._doc.actorId
     if (req.query.from) {
-      setDistance(action, req.query.from)
+      action.distance = distance(action.loc.coordinates, req.query.from)
     }
     res.send(action)
   })

--- a/src/routes/actions.js
+++ b/src/routes/actions.js
@@ -1,5 +1,5 @@
 const router = require('express').Router()
-const {apiRenderCsv, searchCriteria} = require('../utils')
+const {apiRenderCsv, searchCriteria, setDistance} = require('../utils')
 
 const Action = require('../models/action')
 
@@ -42,7 +42,7 @@ router
     if (from) {
       actions = await Action.aggregate(criteria)
       actions.forEach(action => {
-        action.location = location
+        setDistance(action, location)
       })
       actions.sort((a, b) => a.distance - b.distance)
       actions = actions.splice(0, limit)
@@ -65,7 +65,7 @@ router
     action._doc.actor = action.actorId // actorId should be called "actor"!
     delete action._doc.actorId
     if (req.query.from) {
-      action.location = req.query.from
+      setDistance(action, req.query.from)
     }
     res.send(action)
   })

--- a/src/routes/actors.js
+++ b/src/routes/actors.js
@@ -1,5 +1,5 @@
 const router = require('express').Router()
-const { renderFormat, searchCriteria, version, setDistance } = require('../utils')
+const { renderFormat, searchCriteria, version, distance } = require('../utils')
 const { allowDepartmentsFilter } = require('../query')
 const Actor = require('../models/actor')
 const Action = require('../models/action')
@@ -49,7 +49,7 @@ router
     if (from) {
       actors = await Actor.find(criteria)
       actors.forEach(actor => {
-        setDistance(actor, location)
+        actor.distance = distance(actor.loc.coordinates, location)
       })
       actors.sort((a, b) => a.distance - b.distance)
       if (limit !== -1) {
@@ -66,7 +66,7 @@ router
       _id: req.params.id
     })
     actor.actions = await Action.find({actorId: actor._id})
-    setDistance(actor, req.query.from)
+    actor.distance = distance(actor.loc.coordinates, req.query.from)
     res.send(actor)
   })
 

--- a/src/routes/actors.js
+++ b/src/routes/actors.js
@@ -1,5 +1,5 @@
 const router = require('express').Router()
-const { renderFormat, searchCriteria, version } = require('../utils')
+const { renderFormat, searchCriteria, version, setDistance } = require('../utils')
 const { allowDepartmentsFilter } = require('../query')
 const Actor = require('../models/actor')
 const Action = require('../models/action')
@@ -49,7 +49,7 @@ router
     if (from) {
       actors = await Actor.find(criteria)
       actors.forEach(actor => {
-        actor.location = location
+        setDistance(actor, location)
       })
       actors.sort((a, b) => a.distance - b.distance)
       if (limit !== -1) {
@@ -66,7 +66,7 @@ router
       _id: req.params.id
     })
     actor.actions = await Action.find({actorId: actor._id})
-    actor.location = req.query.from
+    setDistance(actor, req.query.from)
     res.send(actor)
   })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,8 +3,9 @@ const Version = require('./models/version')
 const { departmentFromPostalCode } = require('./mongoutils')
 
 function distance (latlng1 = [], latlng2 = []) {
-  const [lat1, lng1] = latlng1
-  const [lat2, lng2] = latlng2
+  if (!latlng1[0] || !latlng2[0]) return
+  const [lat1, lng1] = (typeof (latlng1) === 'string') ? latlng1.split(',').map(v => Number(v)) : latlng1
+  const [lat2, lng2] = (typeof (latlng2) === 'string') ? latlng2.split(',').map(v => Number(v)) : latlng2
   const R = 6371 // Radius of the earth in km
   const dLat = deg2rad(lat2 - lat1) // deg2rad below
   const dLon = deg2rad(lng2 - lng1)
@@ -79,12 +80,6 @@ function version (model, objects) {
   }))
 }
 
-function setDistance (resource, latLng) {
-  if (!resource.loc.coordinates[0]) return
-  if (typeof (latLng) === 'string') latLng = latLng.split(',').map(v => Number(v))
-  resource.distance = distance(latLng, resource.loc.coordinates)
-}
-
 module.exports = {
   distance,
   isLatLngString,
@@ -92,6 +87,5 @@ module.exports = {
   apiRenderCsv,
   version,
   departmentFromPostalCode,
-  renderFormat,
-  setDistance
+  renderFormat
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,6 +79,12 @@ function version (model, objects) {
   }))
 }
 
+function setDistance (resource, latLng) {
+  if (!resource.loc.coordinates[0]) return
+  if (typeof (latLng) === 'string') latLng = latLng.split(',').map(v => Number(v))
+  resource.distance = distance(latLng, resource.loc.coordinates)
+}
+
 module.exports = {
   distance,
   isLatLngString,
@@ -86,5 +92,6 @@ module.exports = {
   apiRenderCsv,
   version,
   departmentFromPostalCode,
-  renderFormat
+  renderFormat,
+  setDistance
 }


### PR DESCRIPTION
Jusqu'à maintenant, il y avait une bidouille un peu bizarre pour obtenir la distance d'une ressource (action, acteur) par rapport à un paramètre passé en entrée :

```
actor.location = qqchose
```

Ça posait plusieurs problèmes, entre-autres : 
- faire `actor.location = qqchose` pour définir en réalité une propriété `distance` n'est pas parlant (**expressivité**)
- l'objet possède déjà une propriété `loc`, ce n'est pas évident de comprendre la **différence** entre `loc` et `location`
- l'objet se retouve **pollué** par une nouvelle propriété `location` qui est une copie partielle de `loc`.
- l'**intention** n'est pas visible et les conséquences encore moins quand on lit le code.
 - mais surtout ça **ne marche pas avec mongoose**. En effet, selon la façon dont on fait la requête, il est possible que mongoose n'applique pas les setters. C'est le cas par exemple quand une aggrégation est faite : les setters ne sont pas appliqués sur l'objet.
 - **Duplication** de code entre les modèles `Actor` et `Action`.

J'ai supprimé du code, factorisé et remplacé par une fonction `setDistance` qui opère une mutation. 

Side note: Cette mutation me semble acceptable, j'ai voulu passer en immutable et je me suis rendu compte que ça n'apportait rien à part la satisfaction de se dire "je fais du code immutable", le `set` étant par contrat une opération de mutation.

@vinyll Bonne relecture, j'aurai besoin de merger ça avant de livrer les corrections sur le front (je n'avais pas vu ce bug ce matin, donc je pensais que les distances étaient settées, mais non).